### PR TITLE
Check for region in AWS_REGION environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Your secret names should have a delimiter separating the namespace, environment 
 
 ## Permissions
 
-You'll need to give your application or service permission to to access your secrets. Start off by creating the following [AIM Policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html). 
+You'll need to give your application or service permission to access your secrets. Start off by creating the following [AIM Policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html). 
 
 ```json
 {
@@ -186,7 +186,7 @@ There are a few handy CLI tools in the bin directory to help you get started. It
 npm install --global @jwerre/secrets
 ```
 
-All of the folloing commands have arguments which you can learn more about by using the `--help` flag.
+All of the following commands have arguments which you can learn more about by using the `--help` flag.
 
 ### Retrieve Configuration Object
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const {config} = require('secrets');
 | Option 	| Type 				| Description	|
 | -			| -					| -				|
 | delimiter | String			| delimiter used in secret names (default:`/`). |
-| region	| String			| The AWS region where your secrets are saved. (default: us-west-2) |
+| region	| String			| The AWS region where your secrets are saved. (default: AWS_PROFILE environment variable or us-west-2 if unset) |
 | env 		| String  			| The environment or stage the secret belongs to e.g.: `staging/database/secret`. This is important when generating the configuration so that only secrets for specific environments are loaded. If not provided `process.env.NODE_ENV` is used. |
 | namespace | String\|Array 	| An optional namespace to be prepended. e.g.: `my-namespace/production/database/secret`. For multiple namespaces use an array. |
 | all 		| Boolean  			| Ignore the environment and retrieve all secrets. |

--- a/bin/create-secrets.js
+++ b/bin/create-secrets.js
@@ -23,7 +23,7 @@ function showHelp () {
 	console.log(`
 Deploy configuration file to AWS Secrets Manager.
 
-Usage: create-config --verbose --kms 123456789-123456789-1234567890 /path/to/my/config.<yaml|json>
+Usage: create-secrets --verbose --kms 123456789-123456789-1234567890 /path/to/my/config.<yaml|json>
 
 Options:
 -h, --help		Show help.

--- a/bin/create-secrets.js
+++ b/bin/create-secrets.js
@@ -12,7 +12,7 @@ const REGION = 'us-west-2';
 const DELIMITER = '/';
 
 const stdin = argv._[0] || argv.i || argv.in;
-const region = argv.r || argv.region || REGION;
+const region = argv.r || argv.region || process.env.AWS_REGION || REGION;
 const kms = argv.k || argv.kms;
 const env = argv.env || argv.e || ENV;
 const namespace = argv.namespace || argv.n;
@@ -28,7 +28,7 @@ Usage: create-config --verbose --kms 123456789-123456789-1234567890 /path/to/my/
 Options:
 -h, --help		Show help.
 -v, --verbose		Verbose output.
--r, --region		The AWS SecretsManager region (default: ${REGION}).
+-r, --region		The AWS Secrets Manager region (default: AWS_PROFILE environment variable or ${REGION} if unset).
 -e, --env		Which environment to use in the secret name (default: ${ENV}).
 -k, --kms		KMS key id to use for encryption.
 -n, --namespace		Namespace of all parameters.

--- a/bin/delete-secrets.js
+++ b/bin/delete-secrets.js
@@ -27,14 +27,14 @@ function showHelp () {
 Delete all secrets from AWS Secrets Manager within a region, environment and namespace.
 By default, you will be prompted for confirmation deleting.
 
-!! This is desctructive, be careful using it !!
+!! This is destructive, be careful using it !!
 
 Usage: delete-config --namespace my-namespace --env staging
 
 Options:
 -h, --help		Show help.
 -v, --verbose		Verbose output.
--e, --env		Which environment to use (defaut:${ENV}).
+-e, --env		Which environment to use (default: ${ENV}).
 -f, --force		Force delete without recovery
 -d, --dry		Dry run.
 -q, --quiet		Disable confirmation prompt.

--- a/bin/delete-secrets.js
+++ b/bin/delete-secrets.js
@@ -18,7 +18,7 @@ const quiet = argv.q || argv.quiet;
 const verbose = argv.v || argv.verbose;
 const env = argv.e || argv.env || ENV;
 const namespace = argv.n || argv.namespace;
-const region = argv.r || argv.region || REGION;
+const region = argv.r || argv.region || process.env.AWS_REGION || REGION;
 const secretsmanager = new AWS.SecretsManager({region:region});
 
 
@@ -39,7 +39,7 @@ Options:
 -d, --dry		Dry run.
 -q, --quiet		Disable confirmation prompt.
 -n, --namespace		Namespace of all parameters (optional).
--r, --region		AWS region where secrets are stored.
+-r, --region		AWS region where secrets are stored (default: AWS_PROFILE environment variable or ${REGION} if unset)
 `);
 
 	return process.exit();

--- a/bin/delete-secrets.js
+++ b/bin/delete-secrets.js
@@ -29,7 +29,7 @@ By default, you will be prompted for confirmation deleting.
 
 !! This is destructive, be careful using it !!
 
-Usage: delete-config --namespace my-namespace --env staging
+Usage: delete-secrets --namespace my-namespace --env staging
 
 Options:
 -h, --help		Show help.

--- a/bin/delete-secrets.js
+++ b/bin/delete-secrets.js
@@ -38,7 +38,7 @@ Options:
 -f, --force		Force delete without recovery
 -d, --dry		Dry run.
 -q, --quiet		Disable confirmation prompt.
--n, --namespace		Namespace of all parameters (optional).
+-n, --namespace		Namespace of all parameters
 -r, --region		AWS region where secrets are stored (default: AWS_PROFILE environment variable or ${REGION} if unset)
 `);
 

--- a/bin/get-config.js
+++ b/bin/get-config.js
@@ -8,7 +8,7 @@ const ENV = 'development';
 const REGION = 'us-west-2';
 
 const env = argv.env || argv.e || ENV;
-const region = argv.r || argv.region || REGION;
+const region = argv.r || argv.region || process.env.AWS_REGION || REGION;
 const namespace = argv.namespace || argv.n;
 const pretty = argv.pretty || argv.p;
 const delimiter = argv.delimiter || argv.d;
@@ -23,7 +23,7 @@ Usage: get-config --namespace mynamespace --env production --pretty
 
 Options:
 -h, --help		Show help.
--r, --region		The AWS SecretsManager region (default: ${REGION}).
+-r, --region		The AWS Secrets Manager region (default: AWS_PROFILE environment variable or ${REGION} if unset).
 -e, --env		Which environment to use in the secret name (default: ${ENV}).
 -d, --delimiter		Secret name delimiter (default: /).
 -p, --pretty		Pretty output

--- a/bin/get-config.js
+++ b/bin/get-config.js
@@ -17,7 +17,7 @@ const time = argv.time || argv.t;
 
 function showHelp () {
 	console.log(`
-Retrive all secrets from AWS Secrets Manager. 
+Retrieve all secrets from AWS Secrets Manager. 
 
 Usage: get-config --namespace mynamespace --env production --pretty
 
@@ -29,7 +29,7 @@ Options:
 -p, --pretty		Pretty output
 -a, --all		Ignore the environment and retrieve all secrets (default: false).
 -n, --namespace		Namespace of all parameters.
--t, --time		Display time it takes to retireve config.
+-t, --time		Display time it takes to retrieve config.
 `);
 
 	return process.exit();

--- a/bin/get-config.js
+++ b/bin/get-config.js
@@ -6,12 +6,13 @@ const {inspect} = require('util');
 
 const ENV = 'development';
 const REGION = 'us-west-2';
+const DELIMITER = '/';
 
 const env = argv.env || argv.e || ENV;
 const region = argv.r || argv.region || process.env.AWS_REGION || REGION;
 const namespace = argv.namespace || argv.n;
 const pretty = argv.pretty || argv.p;
-const delimiter = argv.delimiter || argv.d;
+const delimiter = argv.delimiter || argv.d || DELIMITER;
 const all = argv.all || argv.a;
 const time = argv.time || argv.t;
 
@@ -25,7 +26,7 @@ Options:
 -h, --help		Show help.
 -r, --region		The AWS Secrets Manager region (default: AWS_PROFILE environment variable or ${REGION} if unset).
 -e, --env		Which environment to use in the secret name (default: ${ENV}).
--d, --delimiter		Secret name delimiter (default: /).
+-d, --delimiter		Secret name delimiter (default: ${DELIMITER}).
 -p, --pretty		Pretty output
 -a, --all		Ignore the environment and retrieve all secrets (default: false).
 -n, --namespace		Namespace of all parameters.

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -13,7 +13,7 @@ class Secrets {
 	/**	
 	 * @constructor
 	 * @param  {Object} options class options
-	 * @param  {String} options.region The AWS region where your secrets saved (default:'us-west-2').
+	 * @param  {String} options.region The AWS region where your secrets saved (default: AWS_PROFILE environment variable or 'us-west-2' if unset).
 	 * @param  {String} options.delimiter delimiter used in key names (default:'/')
 	 * @param  {String} options.env The environment or stage the secret belongs to
 	 * e.g.: staging/database/secret. This is important when generating secret 
@@ -29,7 +29,7 @@ class Secrets {
 		
 		this.env = options.env || process.env.NODE_ENV;
 
-		this.region = options.region || DEFAULT_REGION;
+		this.region = options.region || process.env.AWS_REGION || DEFAULT_REGION;
 		
 		if (options.all) {
 			this.env = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@jwerre/secrets",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jwerre/secrets",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Synchronously retrieve all secretes from AWS Secrets Manager and create a tidy JSON object.",
     "main": "index.js",
     "homepage": "https://github.com/jwerre/secrets/blob/master/README.md",


### PR DESCRIPTION
There are a few ways the AWS region is typically set:
1. In the constructor of the relevant client in the SDK (As used in the Secrets Manager client in this project)
2. Using the global config object
3. Using an environment variable (`AWS_REGION`)
4. Using profiles

Source: [Setting the AWS region - AWS SDK for JavaScript v2](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html)

Option 1 is supported by this library. Options 2 and 3 do not work because the region is always passed in to the constructor and this value takes precedence. This pull request adds support for using option 3 by checking the environment variable for a value before defaulting to the hard-coded default region.

Additionally:
1. Some of the help output and documentation has been updated to document the usage of the environment variables, reference the correct command names and fix some typos
2. The `get-config` command did not have a default value for the delimiter as mentioned in the help output, so I have added a default