### PR TITLE
made sync functions synchronous

### DIFF
--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -197,7 +197,7 @@ class Secrets {
 	 * @param  {String} options.stage staging label attached to the version
 	 * @param  {String} options.raw return all the raw data from AWS instead of 
 	 * 	just the secret
-	 * @return {Promise} A Promise contaning secret details
+	 * @return {Object} An Object contaning secret details
 	 */	 
 	getSecretSync (options={}) {
 
@@ -211,11 +211,8 @@ class Secrets {
 		
 		let input;
 		
-		try {
-			input = JSON.stringify(args);
-		} catch (err) {
-			return Promise.reject(err);
-		}
+		
+		input = JSON.stringify(args); // This could throw, but we cannot handle it
 		
 		let result = spawnSync( 'node', [ __dirname + '/readline' ], {
 			input: input,

--- a/test.js
+++ b/test.js
@@ -175,16 +175,12 @@ describe('Secrets', function() {
 
 	});
 
-	it('should synchronously retrieve a single secret string', async function () {
+	it('should synchronously retrieve a single secret string', function () {
 		
 		let secret,
 			id = '__secrets__/unit-tesing/secret2';
 
-		try {
-			secret = await secrets.getSecretSync( {id:id} );
-		} catch (err) {
-			return Promise.reject(err);
-		}
+		secret = secrets.getSecretSync( {id:id} );
 
 		assert.ok(secret);
 		assert.ok(Object.prototype.toString.call(secret) === '[object String]');
@@ -192,17 +188,13 @@ describe('Secrets', function() {
 
 	});
 
-	it('should synchronously retrieve a single secret and return a secret object', async function () {
+	it('should synchronously retrieve a single secret and return a secret object', function () {
 		
 		
 		let secret,
 			id = '__secrets__/unit-tesing/secret1';
 
-		try {
-			secret = await secrets.getSecretSync( {id:id} );
-		} catch (err) {
-			return Promise.reject(err);
-		}
+		secret = secrets.getSecretSync( {id:id} );
 
 		assert.ok(secret);
 		assert.ok(Object.prototype.toString.call(secret) === '[object Object]');
@@ -212,16 +204,12 @@ describe('Secrets', function() {
 
 	});
 
-	it('should synchronously retrieve a single secret mixed array', async function () {
+	it('should synchronously retrieve a single secret mixed array', function () {
 		
 		let secret,
 			id = '__secrets__/unit-tesing/secret6';
 
-		try {
-			secret = await secrets.getSecretSync( {id:id} );
-		} catch (err) {
-			return Promise.reject(err);
-		}
+		secret = secrets.getSecretSync( {id:id} );
 
 		assert.ok(secret);
 		assert.ok(Object.prototype.toString.call(secret) === '[object Array]');
@@ -230,18 +218,14 @@ describe('Secrets', function() {
 	});
 
 
-	it('should synchronously retrieve a single secret and return the raw AWS response', async function () {
+	it('should synchronously retrieve a single secret and return the raw AWS response', function () {
 		
 		
 		let secret,
 			item = secretCache[Math.floor(Math.random() * secretCache.length)];
 		
 
-		try {
-			secret = await secrets.getSecretSync( {id: item.Name, raw: true} );
-		} catch (err) {
-			return Promise.reject(err);
-		}
+		secret = secrets.getSecretSync( {id: item.Name, raw: true} );
 		
 		assert.ok(secret);
 		assert.ok(secret.hasOwnProperty('Name'));


### PR DESCRIPTION
`getSecretSync` does not need to be an async function. Needlessly making it async could cause problems for consumers. For example, if a consumer needs database credentials *before* setting up a sychronous action, having this function return a Promise would cause problems for that consumer as it forces them to take a trip to "callback hell".

Resolves #7 